### PR TITLE
docs: clarify Project ID location and JSON References setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,11 @@ spec:
 1. Log in to your [Flagsmith dashboard](https://app.flagsmith.com)
 2. Go to **Organisation Settings** > **API Keys**
 3. Create or copy your **Admin API Key**
-4. Find your **Project ID** in the URL or project settings
+4. Find your **Project ID**:
+   - First, enable **Show JSON References** in your account settings (under the Developer section)
+   - Navigate to your project
+   - Click on **Project Settings**
+   - The Project ID is shown in the JSON data as `"id"` (it's a number like `1`, not the UUID)
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -95,14 +95,11 @@ spec:
 
 ## Getting your Flagsmith credentials
 
-1. Log in to your [Flagsmith dashboard](https://app.flagsmith.com)
-2. Go to **Organisation Settings** > **API Keys**
-3. Create or copy your **Admin API Key**
-4. Find your **Project ID**:
-   - First, enable **Show JSON References** in your account settings (under the Developer section)
-   - Navigate to your project
-   - Click on **Project Settings**
-   - The Project ID is shown in the JSON data as `"id"` (it's a number like `1`, not the UUID)
+You'll need two pieces of information from Flagsmith:
+- **Admin API Key** - for authenticating API requests
+- **Project ID** - to identify which project's flags to display
+
+For detailed instructions on obtaining these credentials, see the [Backstage integration documentation](https://docs.flagsmith.com/third-party-integrations/backstage) in the official Flagsmith docs
 
 ## Development
 


### PR DESCRIPTION
## Summary

Improves the README by referencing the official Flagsmith documentation for credential setup instead of duplicating instructions.

## Benefits

1. **Single source of truth** - Users get instructions from the official Flagsmith docs
2. **Reduced maintenance** - No need to keep two sets of instructions in sync
3. **Always up-to-date** - Users automatically see the latest instructions
4. **More detailed** - The official docs provide comprehensive step-by-step guidance

## Changes

- Replaced detailed credential instructions with a link to [Backstage integration documentation](https://docs.flagsmith.com/third-party-integrations/backstage)
- Listed the required credentials (Admin API Key and Project ID) with brief descriptions
- Simplified the "Getting your Flagsmith credentials" section

🤖 Generated with [Claude Code](https://claude.com/claude-code)